### PR TITLE
[DX-1080] Setup GitHub Copilot for private dependencies

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,27 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [".github/workflows/copilot-setup-steps.yml"]
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on:
+      group: ubuntu-copilot-core
+    container:
+      image: europe-west3-docker.pkg.dev/flink-core-shared/copilot-container-images/golang:v1
+      options: --volume /home/runner:/home/runner --cap-add=NET_ADMIN --cap-add=NET_RAW
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Copilot Setup Go
+        uses: goflink/github-actions/copilot-setup-go@v2
+        with:
+          copilot-ssh-key: ${{ secrets.COPILOT_PRIVATE_SSH_KEY }}


### PR DESCRIPTION
## 🚀 GitHub Copilot Setup for Private Dependencies

This PR adds the GitHub Copilot setup workflow to enable automated dependency resolution for private GoFlink repositories.

---

### What's Included?

✅ `.github/workflows/copilot-setup-steps.yml` - Workflow that configures Copilot for Go private dependencies
✅ `COPILOT_PRIVATE_SSH_KEY` secret added to `copilot` environment
ℹ️ No private GoFlink dependencies found in go.mod

---

### Private Dependencies Found
No private GoFlink dependencies detected.

---

### ✅ Copilot Bot Access Granted
No repository access was granted (no private dependencies found or all access grants failed).

---

### How It Works

1. The workflow triggers on:
   - Manual workflow dispatch
   - Pull requests modifying the workflow file
   - Copilot session starts in the repository

2. Uses the `copilot-setup-go` GitHub Action to:
   - Enable Copilot to fetch private GoFlink dependencies for sessions
   
3. The Copilot bot user has read-only access to dependency repositories for Copilot to be able to fetch them.

---

### Testing the Setup

After merging this PR, GitHub Copilot will automatically have access to your private dependencies. You can verify this by:

1. The workflow will run on PR creation to validate the setup
2. After the PR is merged, start a Copilot session in the repository and check if private dependencies are resolved correctly.

---

❓ **Got questions?**
Reach out to [#ask-platform](https://goflink.slack.com/archives/C01M4MM051A) for assistance.

---

🤖 This PR was generated by [Temporal Workflow](https://api.shared.goflink.com/temporal/ui/namespaces/default/workflows/CopilotSetup-0).
